### PR TITLE
Revert "regmap: Fix regmap_bulk_read in BE mode"

### DIFF
--- a/drivers/base/regmap/regmap.c
+++ b/drivers/base/regmap/regmap.c
@@ -1586,7 +1586,7 @@ int regmap_bulk_read(struct regmap *map, unsigned int reg, void *val,
 					  &ival);
 			if (ret != 0)
 				return ret;
-			map->format.format_val(val + (i * val_bytes), ival, 0);
+			memcpy(val + (i * val_bytes), &ival, val_bytes);
 		}
 	}
 


### PR DESCRIPTION
This reverts commit c9f4682139e837bb46eb0e19a0a728c573cc2ab4.

This introduces excessive CPU cycle wastes on arizona IRQ,
don't know why.

Signed-off-by: Park Ju Hyung qkrwngud825@gmail.com
