### PR TITLE
dtb: fix zImage-dtb build

### DIFF
--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -15,7 +15,7 @@ ifneq ($(MACHINE),)
 include $(srctree)/$(MACHINE)/Makefile.boot
 endif
 
-include $(srctree)/arch/arm/boot/dts/qcom/Makefile
+include $(srctree)/arch/arm/boot/dts/lge/Makefile
 ifneq ($(DTSSUBDIR),)
 DTSSUBDIR_INCS=$(foreach DIR, $(DTSSUBDIR), $(addsuffix /Makefile, $(addprefix $(srctree)/arch/arm/boot/dts/, $(DIR))))
 include $(DTSSUBDIR_INCS)


### PR DESCRIPTION
Failed make to zImage-dtb because of lge mistake
